### PR TITLE
fix(voice): handle missing recognition service and unblock pipe deadlock

### DIFF
--- a/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
+++ b/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
@@ -20,9 +20,11 @@ import io.rebble.libpebblecommon.voice.TranscriptionResult
 import io.rebble.libpebblecommon.voice.VoiceEncoderInfo
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 import logcat.logcat
 import si.inova.kotlinova.core.reporting.ErrorReporter
@@ -118,59 +120,74 @@ class TranscriptionProviderImpl(
       speechRecognizer
    }
 
-   // The recognizer can fire onResults and stop reading the pipe before the watch
-   // finishes streaming. The pipe then fills and writeStream.write() blocks forever.
-   // Close the pipe the moment finishedReceiver completes — the in-flight write throws
-   // IOException, which we swallow.
+   // Decode and pipe watch audio to the SpeechRecognizer, breaking three possible
+   // deadlocks:
+   //   1. Recognizer fires onResults early and stops reading the pipe: the pipe
+   //      fills and the next write() blocks forever.
+   //   2. Recognizer never fires onResults (waiting for EOF) while audio source
+   //      ends naturally via StopTransfer: same pipe-fills-then-blocks symptom,
+   //      but we never see the recognizer signal completion.
+   //   3. Recognizer is slow consuming the pipe while the watch streams faster
+   //      than it can process: pipe fills mid-stream, write blocks before either
+   //      audio end or recognition complete signals fire.
+   //
+   // Decode runs on its own coroutine and feeds an unbounded channel — it always
+   // drains the source flow regardless of how fast the writer can keep up.
+   // A watcher coroutine closes the pipe (interrupting any blocked write with
+   // IOException) when either the recognizer completes or the audio source ends.
+   @Suppress("BlockingMethodInNonBlockingContext") // We already are on IO
    private suspend fun pipeAudioWithEarlyTermination(
       speexInfo: VoiceEncoderInfo.Speex,
       audioFrames: Flow<UByteArray>,
       speexDecoder: SpeexCodec,
       writeStream: ParcelFileDescriptor.AutoCloseOutputStream,
       finishedReceiver: CompletableDeferred<TranscriptionResult>,
-   ) = coroutineScope {
+   ): Unit = coroutineScope {
+      val targetBufferSize = Short.SIZE_BYTES * speexInfo.frameSize
+      val decodedFrames = Channel<ByteArray>(Channel.UNLIMITED)
+      val audioEnded = CompletableDeferred<Unit>()
+
       val closeWatcher = launch {
-         finishedReceiver.await()
+         select<Unit> {
+            finishedReceiver.onAwait { }
+            audioEnded.onAwait { }
+         }
+         logcat { "Closing audio pipe to deliver EOF to recognizer" }
          runCatching { writeStream.close() }
       }
+
+      val decoder = launch {
+         try {
+            audioFrames.collect { frame ->
+               val buffer = ByteArray(targetBufferSize)
+               val result = speexDecoder.decodeFrame(
+                  encodedFrame = frame.asByteArray(),
+                  decodedFrame = buffer,
+                  hasHeaderByte = true,
+               )
+               if (result != SpeexDecodeResult.Success) {
+                  error("Speex decoding failed: $result")
+               }
+               decodedFrames.send(buffer)
+            }
+         } finally {
+            decodedFrames.close()
+            audioEnded.complete(Unit)
+         }
+      }
+
       try {
-         decodeWatchAudioIntoSpeechRecognizerStream(speexInfo, audioFrames, speexDecoder, writeStream, finishedReceiver)
+         for (decoded in decodedFrames) {
+            this@TranscriptionProviderImpl.logcat { "Wrote audio stream packet" }
+            if (finishedReceiver.isCompleted) continue
+            writeStream.write(decoded, 0, targetBufferSize)
+         }
       } catch (e: IOException) {
-         logcat { "Pipe closed after recognition completed: ${e.message ?: "no message"}" }
+         logcat { "Pipe closed during write: ${e.message ?: "no message"}" }
       } finally {
+         decoder.cancel()
          closeWatcher.cancel()
       }
-   }
-
-   @Suppress("BlockingMethodInNonBlockingContext") // We already are on IO
-   private suspend fun decodeWatchAudioIntoSpeechRecognizerStream(
-      speexInfo: VoiceEncoderInfo.Speex,
-      audioFrames: Flow<UByteArray>,
-      speexDecoder: SpeexCodec,
-      writeStream: ParcelFileDescriptor.AutoCloseOutputStream,
-      finishedReceiver: CompletableDeferred<TranscriptionResult>,
-   ) {
-      val targetBufferSize = Short.SIZE_BYTES * speexInfo.frameSize
-      val targetBuffer = ByteArray(targetBufferSize)
-
-      audioFrames.collect { frame ->
-         val result = speexDecoder.decodeFrame(
-            encodedFrame = frame.asByteArray(),
-            decodedFrame = targetBuffer,
-            hasHeaderByte = true,
-         )
-         if (result != SpeexDecodeResult.Success) {
-            error("Speex decoding failed: $result")
-         }
-         this@TranscriptionProviderImpl.logcat { "Wrote audio stream packet" }
-
-         if (finishedReceiver.isCompleted) {
-            // Speech recognizer has already finished. We cannot write more data to it
-         } else {
-            writeStream.write(targetBuffer, 0, targetBufferSize)
-         }
-      }
-      writeStream.close()
    }
 
    override suspend fun canServeSession(): Boolean {

--- a/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
+++ b/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.media.AudioFormat
 import android.os.Build
 import android.os.ParcelFileDescriptor
+import android.provider.Settings
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import androidx.annotation.RequiresApi
@@ -19,10 +20,13 @@ import io.rebble.libpebblecommon.voice.TranscriptionResult
 import io.rebble.libpebblecommon.voice.VoiceEncoderInfo
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
 import si.inova.kotlinova.core.reporting.ErrorReporter
+import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
 @Inject
@@ -30,6 +34,7 @@ import kotlin.coroutines.cancellation.CancellationException
 class TranscriptionProviderImpl(
    private val context: Context,
    private val errorReporter: ErrorReporter,
+   private val voiceSetupNotifier: VoiceSetupNotifier,
 ) : TranscriptionProvider {
    @Suppress("NestedBlockDepth") // It uses a lot of .use {}, which increase nesting. It's fine otherwise.
    override suspend fun transcribe(
@@ -46,6 +51,14 @@ class TranscriptionProviderImpl(
 
       if (!SpeechRecognizer.isRecognitionAvailable(context)) {
          return staticSuccess(context.getString(R.string.error_no_voice_recognizer))
+      }
+
+      // isRecognitionAvailable() returns true even when no service is the system default.
+      val defaultService = Settings.Secure.getString(context.contentResolver, VOICE_RECOGNITION_SERVICE_SETTING)
+      if (defaultService.isNullOrBlank()) {
+         logcat { "No default voice recognition service selected" }
+         voiceSetupNotifier.showNoDefaultVoiceServiceNotification()
+         return staticSuccess(context.getString(R.string.error_no_default_voice_service))
       }
 
       try {
@@ -65,13 +78,7 @@ class TranscriptionProviderImpl(
                   this@TranscriptionProviderImpl.logcat { "Created speech recognizer" }
 
                   return try {
-                     decodeWatchAudioIntoSpeechRecognizerStream(
-                        speexInfo,
-                        audioFrames,
-                        speexDecoder,
-                        writeStream,
-                        finishedReceiver
-                     )
+                     pipeAudioWithEarlyTermination(speexInfo, audioFrames, speexDecoder, writeStream, finishedReceiver)
                      this@TranscriptionProviderImpl.logcat { "Submitted all the audio, awaiting completed recognition" }
                      finishedReceiver.await()
                         .also {
@@ -111,6 +118,30 @@ class TranscriptionProviderImpl(
       speechRecognizer
    }
 
+   // The recognizer can fire onResults and stop reading the pipe before the watch
+   // finishes streaming. The pipe then fills and writeStream.write() blocks forever.
+   // Close the pipe the moment finishedReceiver completes — the in-flight write throws
+   // IOException, which we swallow.
+   private suspend fun pipeAudioWithEarlyTermination(
+      speexInfo: VoiceEncoderInfo.Speex,
+      audioFrames: Flow<UByteArray>,
+      speexDecoder: SpeexCodec,
+      writeStream: ParcelFileDescriptor.AutoCloseOutputStream,
+      finishedReceiver: CompletableDeferred<TranscriptionResult>,
+   ) = coroutineScope {
+      val closeWatcher = launch {
+         finishedReceiver.await()
+         runCatching { writeStream.close() }
+      }
+      try {
+         decodeWatchAudioIntoSpeechRecognizerStream(speexInfo, audioFrames, speexDecoder, writeStream, finishedReceiver)
+      } catch (e: IOException) {
+         logcat { "Pipe closed after recognition completed: ${e.message ?: "no message"}" }
+      } finally {
+         closeWatcher.cancel()
+      }
+   }
+
    @Suppress("BlockingMethodInNonBlockingContext") // We already are on IO
    private suspend fun decodeWatchAudioIntoSpeechRecognizerStream(
       speexInfo: VoiceEncoderInfo.Speex,
@@ -146,3 +177,6 @@ class TranscriptionProviderImpl(
       return true
    }
 }
+
+// Settings.Secure.VOICE_RECOGNITION_SERVICE is @hide; the underlying key is stable.
+private const val VOICE_RECOGNITION_SERVICE_SETTING = "voice_recognition_service"

--- a/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/VoiceSetupNotifier.kt
+++ b/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/VoiceSetupNotifier.kt
@@ -1,0 +1,57 @@
+package com.matejdro.micropebble.voice
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.getSystemService
+import com.matejdro.micropebble.voice.data.R
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import com.matejdro.micropebble.sharedresources.R as sharedR
+
+@Inject
+@SingleIn(AppScope::class)
+class VoiceSetupNotifier(
+   private val context: Context,
+) {
+   fun showNoDefaultVoiceServiceNotification() {
+      ensureChannel()
+      val intent = Intent(Settings.ACTION_VOICE_INPUT_SETTINGS).apply {
+         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      }
+      val pendingIntent = PendingIntent.getActivity(
+         context,
+         REQUEST_CODE_OPEN_VOICE_SETTINGS,
+         intent,
+         PendingIntent.FLAG_IMMUTABLE,
+      )
+      val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+         .setSmallIcon(sharedR.drawable.ic_mic)
+         .setContentTitle(context.getString(R.string.voice_setup_needed_title))
+         .setContentText(context.getString(R.string.voice_setup_needed_text))
+         .setContentIntent(pendingIntent)
+         .setAutoCancel(true)
+         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+         .build()
+      NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+   }
+
+   private fun ensureChannel() {
+      val channel = NotificationChannel(
+         CHANNEL_ID,
+         context.getString(R.string.voice_setup_channel_name),
+         NotificationManager.IMPORTANCE_DEFAULT,
+      )
+      context.getSystemService<NotificationManager>()!!.createNotificationChannel(channel)
+   }
+}
+
+private const val CHANNEL_ID = "voice_setup_channel_id"
+private const val NOTIFICATION_ID = 12379
+private const val REQUEST_CODE_OPEN_VOICE_SETTINGS = 0

--- a/voice/data/src/main/res/values/strings.xml
+++ b/voice/data/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="error_voice_not_enabled_short">Error: Press \'Enable voice\' in the phone app in Tools</string>
     <string name="error_voice_android_version">Error: sorry, voice recognition is only supported on Android 13+</string>
     <string name="error_no_voice_recognizer">Error: Phone does not have a voice recognition service installed</string>
+    <string name="error_no_default_voice_service">Error: No voice input app set as default on phone. Check phone notifications.</string>
+    <string name="voice_setup_channel_name">Voice setup hints</string>
+    <string name="voice_setup_needed_title">Voice dictation needs setup</string>
+    <string name="voice_setup_needed_text">No voice input service is set as default. Tap to configure.</string>
 </resources>


### PR DESCRIPTION
  Three improvements to watch voice dictation, addressing what users currently see as a generic "Error occurred. Try again." on the watch:
  
  1. **Surface "no default recognition service" up front.**
     `SpeechRecognizer.isRecognitionAvailable()` returns `true` whenever any `RecognitionService` is installed, but `createSpeechRecognizer()` silently binds to nothing
  when no service is set as the system default. Read `Settings.Secure.voice_recognition_service` directly and return a specific error instead of letting the watch fall
  back to the generic message.  
  
  2. **Tap-to-configure phone notification.**
     When the check above fails, post a notification with a `Settings.ACTION_VOICE_INPUT_SETTINGS` intent — the canonical Android intent that resolves to the right
  settings screen regardless of OEM customisation (the path through phone settings varies by Android distribution).
  
  3. **Break the audio pipe deadlock so transcription results actually reach the watch.**
     `TranscriptionProviderImpl` had two related deadlocks that left the watch stuck on "Listening…" with a blinking dot even when the recognizer was working fine:
     - **Early termination:** recognizer fires `onResults` and stops reading the pipe before the watch finishes streaming → pipe fills → blocked `write()` → `transcribe()`
   never reaches `finishedReceiver.await()`.
     - **Slow consumer:** recognizer consumes the pipe slower than the watch streams → pipe fills → blocked `write()` → collector can't process more emissions → audio flow
   can't propagate `StopTransfer` → neither side moves.
  
     Split decode and write into separate coroutines connected by a `Channel`. A watcher coroutine closes the write side of the pipe when **either** `finishedReceiver`
  completes **or** the audio source ends — whichever first. Closing the FD interrupts any blocked `write()` with `IOException`, which we swallow, then proceed to `await()`
   and deliver `DictationResult` back to the watch.

  ## Test plan
  
  - [x] `./gradlew :voice:data:compileDebugKotlin :voice:data:detektDebug` (clean)
  - [x] Manual: phone with no default `voice_recognition_service` shows the new error string and posts a tap-to-configure notification (verified on an AOSP-based ROM)
  - [x] Manual: set `voice_recognition_service` to a real provider (Whisper+), trigger dictation — log shows `Submitted all the audio, awaiting completed recognition`
  followed by recognition completion (no more hang on "Listening…")
  - [ ] Manual on a stock-Android device with Speech Services by Google as the default — confirm no regression
