### PR TITLE
  feat(watch-settings): add global vibration pattern override for notifications and calendar

### DIFF
--- a/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7a30958545d2d20e629e42fabf924e108587f4aff9d5fb9a03b71048f9d351e
-size 43457
+oid sha256:97f2b7acd243a2f1c1e0e1695f6e471fcca4b2b196092fa7e348f65f91a82ea2
+size 63728

--- a/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview_largefont.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview_largefont.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d4ba31a46a6d594dc2d78a42a8d1d05193fdf844275e557f2ab109d1ef56b73
-size 53064
+oid sha256:39c35055442b7a97b7910d6e284a614bfaacfd1e987fdb389cb82418e50d806b
+size 72249

--- a/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview_night.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__WatchSettingsScreenPreview_night.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:162da27721342875a175c205c69a6070727bfc311c21c23886adfacf554ce81a
-size 45967
+oid sha256:7caa1cbf03c3fa34506968370775ed1f07d1a7ecdc5f1a6e327c8d90ea7ba92b
+size 66242

--- a/bluetooth/data/src/main/kotlin/com/matejdro/micropebble/bluetooth/LibPebbleBindings.kt
+++ b/bluetooth/data/src/main/kotlin/com/matejdro/micropebble/bluetooth/LibPebbleBindings.kt
@@ -9,6 +9,7 @@ import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.LockerApi
 import io.rebble.libpebblecommon.connection.NotificationApps
 import io.rebble.libpebblecommon.connection.Scanning
+import io.rebble.libpebblecommon.connection.Vibrations
 import io.rebble.libpebblecommon.connection.WatchPrefs
 import io.rebble.libpebblecommon.connection.Watches
 
@@ -48,4 +49,9 @@ interface LibPebbleBindings {
    fun bindToWatchPrefs(
       libPebble: LibPebble,
    ): WatchPrefs
+
+   @Binds
+   fun bindToVibrations(
+      libPebble: LibPebble,
+   ): Vibrations
 }

--- a/home/ui/src/main/kotlin/com/matejdro/micropebble/watchsettings/WatchSettingsScreen.kt
+++ b/home/ui/src/main/kotlin/com/matejdro/micropebble/watchsettings/WatchSettingsScreen.kt
@@ -20,7 +20,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -47,30 +51,17 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.matejdro.micropebble.home.ui.R
 import com.matejdro.micropebble.navigation.keys.WatchSettingsScreenKey
 import com.matejdro.micropebble.ui.components.ProgressErrorSuccessScaffold
-import si.inova.kotlinova.core.outcome.Outcome
 import com.matejdro.micropebble.ui.debugging.FullScreenPreviews
 import com.matejdro.micropebble.ui.debugging.PreviewTheme
 import io.rebble.libpebblecommon.database.entity.RgbColorPreset
 import io.rebble.libpebblecommon.database.entity.RgbColorWatchPref
+import io.rebble.libpebblecommon.notification.DefaultVibePattern
+import io.rebble.libpebblecommon.notification.VibePattern
 import si.inova.kotlinova.compose.flow.collectAsStateWithLifecycleAndBlinkingPrevention
+import si.inova.kotlinova.core.outcome.Outcome
 import si.inova.kotlinova.navigation.di.ContributesScreenBinding
 import si.inova.kotlinova.navigation.screens.InjectNavigationScreen
 import si.inova.kotlinova.navigation.screens.Screen
-
-private val BACKLIGHT_COLOR_PRESETS = listOf(
-   RgbColorPreset(0x00FF0000u, "Red"),
-   RgbColorPreset(0x00FF7F00u, "Orange"),
-   RgbColorPreset(0x00FFFF00u, "Yellow"),
-   RgbColorPreset(0x007FFF00u, "Lime"),
-   RgbColorPreset(0x0000FF00u, "Green"),
-   RgbColorPreset(0x0000FFFFu, "Cyan"),
-   RgbColorPreset(0x000000FFu, "Blue"),
-   RgbColorPreset(0x007F00FFu, "Purple"),
-   RgbColorPreset(0x00FF00FFu, "Magenta"),
-   RgbColorPreset(0x00FF66CCu, "Pink"),
-   RgbColorPreset(0x00F0D0B0u, "Warm White"),
-   RgbColorPreset(0x00FFFFFFu, "Cool White"),
-)
 
 @InjectNavigationScreen
 @ContributesScreenBinding
@@ -85,6 +76,8 @@ class WatchSettingsScreen(
       WatchSettingsContent(
          state = state::value,
          onColorSelected = viewModel::setBacklightColor,
+         onNotificationVibePatternSelected = viewModel::setOverrideNotificationVibePattern,
+         onCalendarVibePatternSelected = viewModel::setOverrideCalendarVibePattern,
       )
    }
 }
@@ -94,6 +87,8 @@ class WatchSettingsScreen(
 private fun WatchSettingsContent(
    state: () -> Outcome<WatchSettingsState>?,
    onColorSelected: (UInt) -> Unit,
+   onNotificationVibePatternSelected: (String?) -> Unit,
+   onCalendarVibePatternSelected: (String?) -> Unit,
 ) {
    Scaffold(
       topBar = { TopAppBar(title = { Text(stringResource(R.string.watch_settings)) }) },
@@ -132,6 +127,26 @@ private fun WatchSettingsContent(
             CustomRgbPicker(
                currentRgb = watchSettingsState.backlightColor,
                onColorChanged = onColorSelected,
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            VibePatternPicker(
+               title = stringResource(R.string.notification_vibe_title),
+               description = stringResource(R.string.notification_vibe_description),
+               customVibePatterns = watchSettingsState.customVibePatterns,
+               selectedPatternName = watchSettingsState.overrideNotificationVibePattern,
+               onPatternSelected = onNotificationVibePatternSelected,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            VibePatternPicker(
+               title = stringResource(R.string.calendar_vibe_title),
+               description = stringResource(R.string.calendar_vibe_description),
+               customVibePatterns = watchSettingsState.customVibePatterns,
+               selectedPatternName = watchSettingsState.overrideCalendarVibePattern,
+               onPatternSelected = onCalendarVibePatternSelected,
             )
          }
       }
@@ -255,12 +270,115 @@ private fun ColorChannelSlider(
    }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VibePatternPicker(
+   title: String,
+   description: String,
+   customVibePatterns: List<VibePattern>,
+   selectedPatternName: String?,
+   onPatternSelected: (String?) -> Unit,
+) {
+   var expanded by remember { mutableStateOf(false) }
+   val noneLabel = stringResource(R.string.vibe_pattern_none)
+   val defaultLabels = defaultVibePatternLabels()
+   val selectedLabel = if (selectedPatternName == null) {
+      noneLabel
+   } else {
+      defaultLabels[selectedPatternName] ?: selectedPatternName
+   }
+
+   Column {
+      Text(text = title, style = MaterialTheme.typography.titleMedium)
+      Text(
+         text = description,
+         style = MaterialTheme.typography.bodySmall,
+         color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(Modifier.height(8.dp))
+      ExposedDropdownMenuBox(
+         expanded = expanded,
+         onExpandedChange = { expanded = it },
+      ) {
+         OutlinedTextField(
+            value = selectedLabel,
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+            modifier = Modifier
+               .fillMaxWidth()
+               .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+         )
+         ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+         ) {
+            DropdownMenuItem(
+               text = { Text(text = noneLabel) },
+               onClick = {
+                  onPatternSelected(null)
+                  expanded = false
+               },
+            )
+            defaultLabels.forEach { (storageKey, label) ->
+               DropdownMenuItem(
+                  text = { Text(text = label) },
+                  onClick = {
+                     onPatternSelected(storageKey)
+                     expanded = false
+                  },
+               )
+            }
+            customVibePatterns.forEach { pattern ->
+               DropdownMenuItem(
+                  text = { Text(text = pattern.name) },
+                  onClick = {
+                     onPatternSelected(pattern.name)
+                     expanded = false
+                  },
+               )
+            }
+         }
+      }
+   }
+}
+
+@Composable
+private fun defaultVibePatternLabels(): Map<String, String> = mapOf(
+   DefaultVibePattern.Standard.displayName to stringResource(R.string.vibe_pattern_standard),
+   DefaultVibePattern.Pulses.displayName to stringResource(R.string.vibe_pattern_pulses),
+   DefaultVibePattern.Double.displayName to stringResource(R.string.vibe_pattern_double),
+   DefaultVibePattern.Triple.displayName to stringResource(R.string.vibe_pattern_triple),
+   DefaultVibePattern.Bloom.displayName to stringResource(R.string.vibe_pattern_bloom),
+   DefaultVibePattern.Pips.displayName to stringResource(R.string.vibe_pattern_pips),
+   DefaultVibePattern.Ole.displayName to stringResource(R.string.vibe_pattern_ole),
+   DefaultVibePattern.SOS.displayName to stringResource(R.string.vibe_pattern_sos),
+   DefaultVibePattern.OhhhOh.displayName to stringResource(R.string.vibe_pattern_ohhh_oh),
+   DefaultVibePattern.Five.displayName to stringResource(R.string.vibe_pattern_five),
+   DefaultVibePattern.Two.displayName to stringResource(R.string.vibe_pattern_two),
+)
+
 private const val RED_SHIFT = 16
 private const val GREEN_SHIFT = 8
 private const val COLOR_CHANNEL_MASK = 0xFFu
 private const val MAX_COLOR_CHANNEL = 255f
 private const val HEX_COLOR_LENGTH = 6
 private const val HEX_RADIX = 16
+
+private val BACKLIGHT_COLOR_PRESETS = listOf(
+   RgbColorPreset(0x00FF0000u, "Red"),
+   RgbColorPreset(0x00FF7F00u, "Orange"),
+   RgbColorPreset(0x00FFFF00u, "Yellow"),
+   RgbColorPreset(0x007FFF00u, "Lime"),
+   RgbColorPreset(0x0000FF00u, "Green"),
+   RgbColorPreset(0x0000FFFFu, "Cyan"),
+   RgbColorPreset(0x000000FFu, "Blue"),
+   RgbColorPreset(0x007F00FFu, "Purple"),
+   RgbColorPreset(0x00FF00FFu, "Magenta"),
+   RgbColorPreset(0x00FF66CCu, "Pink"),
+   RgbColorPreset(0x00F0D0B0u, "Warm White"),
+   RgbColorPreset(0x00FFFFFFu, "Cool White"),
+)
 
 private fun rgbToHex(r: Int, g: Int, b: Int) =
    String.format(java.util.Locale.ROOT, "%06X", (r shl RED_SHIFT) or (g shl GREEN_SHIFT) or b)
@@ -279,8 +397,17 @@ internal fun WatchSettingsScreenPreview() {
    var color by remember { mutableStateOf(RgbColorWatchPref.BacklightColor.defaultValue) }
    PreviewTheme {
       WatchSettingsContent(
-         state = { Outcome.Success(WatchSettingsState(backlightColor = color)) },
+         state = {
+            Outcome.Success(
+               WatchSettingsState(
+                  backlightColor = color,
+                  customVibePatterns = listOf(VibePattern("My Custom Pattern", listOf(200, 100, 400), bundled = false)),
+               )
+            )
+         },
          onColorSelected = { color = it },
+         onNotificationVibePatternSelected = {},
+         onCalendarVibePatternSelected = {},
       )
    }
 }

--- a/home/ui/src/main/kotlin/com/matejdro/micropebble/watchsettings/WatchSettingsViewModel.kt
+++ b/home/ui/src/main/kotlin/com/matejdro/micropebble/watchsettings/WatchSettingsViewModel.kt
@@ -4,12 +4,15 @@ import androidx.compose.runtime.Stable
 import com.matejdro.micropebble.common.logging.ActionLogger
 import com.matejdro.micropebble.navigation.keys.WatchSettingsScreenKey
 import dev.zacsweers.metro.Inject
+import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.connection.Vibrations
 import io.rebble.libpebblecommon.connection.WatchPrefs
 import io.rebble.libpebblecommon.database.dao.WatchPreference
 import io.rebble.libpebblecommon.database.entity.RgbColorWatchPref
+import io.rebble.libpebblecommon.notification.VibePattern
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import si.inova.kotlinova.core.outcome.CoroutineResourceManager
 import si.inova.kotlinova.core.outcome.Outcome
 import si.inova.kotlinova.navigation.services.ContributesScopedService
@@ -22,6 +25,8 @@ class WatchSettingsViewModel(
    private val resources: CoroutineResourceManager,
    private val actionLogger: ActionLogger,
    private val watchPrefs: WatchPrefs,
+   private val vibrations: Vibrations,
+   private val libPebble: LibPebble,
 ) : SingleScreenViewModel<WatchSettingsScreenKey>(resources.scope) {
 
    private val _state = MutableStateFlow<Outcome<WatchSettingsState>>(Outcome.Progress())
@@ -31,13 +36,20 @@ class WatchSettingsViewModel(
       actionLogger.logAction { "WatchSettingsViewModel.onServiceRegistered()" }
       resources.launchResourceControlTask(_state) {
          emitAll(
-            watchPrefs.watchPrefs.map { prefs ->
+            combine(
+               watchPrefs.watchPrefs,
+               vibrations.vibePatterns(),
+               libPebble.config,
+            ) { prefs, vibePatterns, config ->
                @Suppress("UNCHECKED_CAST")
-               val pref = prefs.firstOrNull { it.pref == RgbColorWatchPref.BacklightColor }
+               val backlightPref = prefs.firstOrNull { it.pref == RgbColorWatchPref.BacklightColor }
                   as? WatchPreference<UInt>
                Outcome.Success(
                   WatchSettingsState(
-                     backlightColor = pref?.valueOrDefault() ?: RgbColorWatchPref.BacklightColor.defaultValue,
+                     backlightColor = backlightPref?.valueOrDefault() ?: RgbColorWatchPref.BacklightColor.defaultValue,
+                     customVibePatterns = vibePatterns.filter { !it.bundled },
+                     overrideNotificationVibePattern = config.notificationConfig.overrideDefaultVibePattern,
+                     overrideCalendarVibePattern = config.notificationConfig.overrideCalendarVibePattern,
                   )
                )
             }
@@ -49,8 +61,37 @@ class WatchSettingsViewModel(
       actionLogger.logAction { "WatchSettingsViewModel.setBacklightColor($rgb)" }
       watchPrefs.setWatchPref(WatchPreference(RgbColorWatchPref.BacklightColor, rgb))
    }
+
+   @Suppress("NullableToStringCall") // patternName=null is meaningful in the log (means "no override")
+   fun setOverrideNotificationVibePattern(patternName: String?) {
+      actionLogger.logAction { "WatchSettingsViewModel.setOverrideNotificationVibePattern($patternName)" }
+      val current = libPebble.config.value
+      libPebble.updateConfig(
+         current.copy(
+            notificationConfig = current.notificationConfig.copy(
+               overrideDefaultVibePattern = patternName,
+            ),
+         ),
+      )
+   }
+
+   @Suppress("NullableToStringCall") // patternName=null is meaningful in the log (means "no override")
+   fun setOverrideCalendarVibePattern(patternName: String?) {
+      actionLogger.logAction { "WatchSettingsViewModel.setOverrideCalendarVibePattern($patternName)" }
+      val current = libPebble.config.value
+      libPebble.updateConfig(
+         current.copy(
+            notificationConfig = current.notificationConfig.copy(
+               overrideCalendarVibePattern = patternName,
+            ),
+         ),
+      )
+   }
 }
 
 data class WatchSettingsState(
    val backlightColor: UInt = RgbColorWatchPref.BacklightColor.defaultValue,
+   val customVibePatterns: List<VibePattern> = emptyList(),
+   val overrideNotificationVibePattern: String? = null,
+   val overrideCalendarVibePattern: String? = null,
 )

--- a/home/ui/src/main/res/values/strings.xml
+++ b/home/ui/src/main/res/values/strings.xml
@@ -38,4 +38,20 @@
     <string name="watch_settings">Watch Settings</string>
     <string name="backlight_color_custom">Custom</string>
     <string name="backlight_color_hex_label">Hex color</string>
+    <string name="notification_vibe_title">Notification Vibration</string>
+    <string name="notification_vibe_description">Override the default vibration pattern for notifications</string>
+    <string name="calendar_vibe_title">Calendar Vibration</string>
+    <string name="calendar_vibe_description">Override the default vibration pattern for calendar reminders</string>
+    <string name="vibe_pattern_none">None</string>
+    <string name="vibe_pattern_standard">Standard</string>
+    <string name="vibe_pattern_pulses">Pulses</string>
+    <string name="vibe_pattern_double">Double</string>
+    <string name="vibe_pattern_triple">Triple</string>
+    <string name="vibe_pattern_bloom">Bloom</string>
+    <string name="vibe_pattern_pips">Pips</string>
+    <string name="vibe_pattern_ole">Olé</string>
+    <string name="vibe_pattern_sos">SOS</string>
+    <string name="vibe_pattern_ohhh_oh">Ohhh, Oh</string>
+    <string name="vibe_pattern_five">Five</string>
+    <string name="vibe_pattern_two">Two</string>
 </resources>


### PR DESCRIPTION
Adds two vibration pattern pickers to Watch Settings — one for notifications, one for calendar reminders. Each shows the bundled `DefaultVibePattern` entries plus any user-created custom patterns, or "None" to fall back to the existing priority chain.
  
  The selected name persists via `LibPebble.updateConfig()`. Notifications pick it up through `BasicNotificationProcessor`'s existing priority chain (global override is the lowest priority, so per-app/per-contact rules still win). Calendar reminders use a new `vibePattern` parameter on `CalendarEvent.toTimelinePin()` / `toTimelineReminder()`, wired through `PhoneCalendarSyncer`.
  
  Pattern labels are localized via R.string while the upstream `displayName` is preserved as the storage / `VibePatternDao` key.
  
  Depends on [matejdro/libpebble3#2](https://github.com/matejdro/libpebble3/pull/2); submodule ref repoints to `origin/micropebble` after that merges.
   
  ## Test plan
  
  - [x] Notifications: pick a non-default, trigger a test notification, watch vibrates with the chosen pattern
  - [x] Calendar: pick a non-default, next reminder fires with the chosen pattern
  - [x] Switch back to None, defaults restored
  - [x] `./gradlew verifyPaparazziDebug` clean
  - [x] `./gradlew :home:ui:runDebugDetekt :home:ui:lintRelease` clean

