### PR TITLE
  fix(voice): break decoder deadlock when recognizer fires before audio ends

### DIFF
--- a/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
+++ b/voice/data/src/main/kotlin/com/matejdro/micropebble/voice/TranscriptionProviderImpl.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withContext
 import logcat.logcat
 import si.inova.kotlinova.core.reporting.ErrorReporter
@@ -120,21 +119,24 @@ class TranscriptionProviderImpl(
       speechRecognizer
    }
 
-   // Decode and pipe watch audio to the SpeechRecognizer, breaking three possible
-   // deadlocks:
-   //   1. Recognizer fires onResults early and stops reading the pipe: the pipe
-   //      fills and the next write() blocks forever.
-   //   2. Recognizer never fires onResults (waiting for EOF) while audio source
-   //      ends naturally via StopTransfer: same pipe-fills-then-blocks symptom,
-   //      but we never see the recognizer signal completion.
-   //   3. Recognizer is slow consuming the pipe while the watch streams faster
-   //      than it can process: pipe fills mid-stream, write blocks before either
-   //      audio end or recognition complete signals fire.
+   // Decode and pipe watch audio to the SpeechRecognizer. Two coroutines plus
+   // the main writer body handle the four termination paths:
    //
-   // Decode runs on its own coroutine and feeds an unbounded channel — it always
-   // drains the source flow regardless of how fast the writer can keep up.
-   // A watcher coroutine closes the pipe (interrupting any blocked write with
-   // IOException) when either the recognizer completes or the audio source ends.
+   //   1. Audio source ends (watch StopTransfer): decoder's finally closes
+   //      the channel and the pipe — writer drains remaining items and exits;
+   //      EOF on the pipe signals the recognizer to fire onResults.
+   //   2. Recognizer fires onResults / onError early: finishedWaiter closes
+   //      the pipe (interrupts any blocked write with IOException) and
+   //      cancels the decoder; writer exits via closed channel or IOException.
+   //   3. Recognizer is a slow consumer and the pipe fills mid-stream:
+   //      the decoder keeps draining the source into the unbounded channel,
+   //      so StopTransfer can still arrive — eventually path 1 or 2 fires.
+   //   4. Recognizer fires early AND the watch sends no more audio and no
+   //      StopTransfer: path 2's decoder.cancel() forces the decoder's
+   //      finally, which closes the channel and frees the writer's for-loop.
+   //
+   // writeStream.close() is idempotent under runCatching, so both paths can
+   // race to close the pipe without coordination.
    @Suppress("BlockingMethodInNonBlockingContext") // We already are on IO
    private suspend fun pipeAudioWithEarlyTermination(
       speexInfo: VoiceEncoderInfo.Speex,
@@ -145,16 +147,6 @@ class TranscriptionProviderImpl(
    ): Unit = coroutineScope {
       val targetBufferSize = Short.SIZE_BYTES * speexInfo.frameSize
       val decodedFrames = Channel<ByteArray>(Channel.UNLIMITED)
-      val audioEnded = CompletableDeferred<Unit>()
-
-      val closeWatcher = launch {
-         select<Unit> {
-            finishedReceiver.onAwait { }
-            audioEnded.onAwait { }
-         }
-         logcat { "Closing audio pipe to deliver EOF to recognizer" }
-         runCatching { writeStream.close() }
-      }
 
       val decoder = launch {
          try {
@@ -172,13 +164,20 @@ class TranscriptionProviderImpl(
             }
          } finally {
             decodedFrames.close()
-            audioEnded.complete(Unit)
+            this@TranscriptionProviderImpl.logcat { "Audio source ended, closing pipe to deliver EOF" }
+            runCatching { writeStream.close() }
          }
+      }
+
+      val finishedWaiter = launch {
+         finishedReceiver.await()
+         this@TranscriptionProviderImpl.logcat { "Recognizer finished, closing pipe and stopping decoder" }
+         runCatching { writeStream.close() }
+         decoder.cancel()
       }
 
       try {
          for (decoded in decodedFrames) {
-            this@TranscriptionProviderImpl.logcat { "Wrote audio stream packet" }
             if (finishedReceiver.isCompleted) continue
             writeStream.write(decoded, 0, targetBufferSize)
          }
@@ -186,7 +185,7 @@ class TranscriptionProviderImpl(
          logcat { "Pipe closed during write: ${e.message ?: "no message"}" }
       } finally {
          decoder.cancel()
-         closeWatcher.cancel()
+         finishedWaiter.cancel()
       }
    }
 


### PR DESCRIPTION

  Follow-up to #110. That PR fixed three deadlocks in `pipeAudioWithEarlyTermination`
  where the writer was blocked on `writeStream.write` (pipe full). 
  
  A fourth deadlock remained where the writer is blocked on the *channel read*, not the   pipe write — closing the pipe doesn't help. 
  
  ## Root cause

  The decoder runs `audioFrames.collect`, decodes Speex → PCM, and pushes into an   unbounded `Channel<ByteArray>`. The writer for-loop reads from that channel and   writes PCM bytes to the recognizer's pipe.  
  
When the recognizer fires `onResults` early (e.g. VAD-based termination) AND   the watch then sends no further audio AND no `StopTransfer`: 

  - the writer is suspended on `for (decoded in decodedFrames)` (channel read,
    not pipe write);
  - the previous fix's `closeWatcher` closes the pipe — but that only unblocks
    writes, not channel reads;
  - the decoder is still suspended inside `audioFrames.collect` waiting for a
    frame the watch will never send, so its `finally` never runs and the channel
    never closes.

  Net result: writer parked on an empty channel that will never close.

  ## Fix

  When the recognizer signals completion first, cancel the decoder. Its `finally`   then closes the channel; the writer's for-loop exits naturally; control returns   to `transcribe()`, which delivers the result via `VoiceSessionManager`.

  Took the opportunity to simplify the surrounding coordination at the same time:

  - `audioEnded: CompletableDeferred<Unit>` is gone
  - `select`-based `closeWatcher` coroutine is gone
  - each termination path closes the pipe directly from its own coroutine
    (decoder's `finally` for the audio-ended path, a small `finishedWaiter`
    for the recognizer-finished path)
  - `writeStream.close()` under `runCatching` is idempotent, so both paths can
    race freely without explicit synchronization

  Net change: +27 / −28 lines on `TranscriptionProviderImpl.kt` — slightly
  *shorter* than the pre-fix version, despite handling one more scenario.

  ## Verification

  Reproduced the original deadlock on `main`: audio streams, recognizer fires,   phone hangs, watch eventually surfaces "dictation app not detected".

  Re-tested on this branch with the same scenario:

  Wrote audio stream packet  [×N]  inbound StopTransfer  Audio source ended, closing pipe to deliver EOF   Pipe closed during write: write interrupted by close() on another thread  Submitted all the audio, awaiting completed recognition   Recognition completed   Voice session completed with result: Success, N words   sending DictationResult 
  
  End-to-end success. The `Submitted all the audio` and `Recognition completed`   lines did not appear pre-fix — they're proof the writer for-loop is now exiting cleanly. 

  ## Test plan

  - [x] Trigger dictation, speak a short phrase, release — transcript appears
        on the watch
  - [x] Trigger dictation, release without speaking — watch shows an error
        cleanly (no hang)
  - [x] Trigger dictation with a slow `RecognitionService` (e.g. Whisper+) —
        either succeeds or surfaces an error (separate timeout fallback tracked
        in `todo.md` voice follow-ups)
  - [x] `./gradlew :voice:data:runDebugDetekt :voice:data:lintRelease` clean
