### PR TITLE
feat(notifications): add per-app toggle to allow duplicate notifications

### DIFF
--- a/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c19303d749808db200825f814d5c0deb253c096cdaac57aaa50bc5c19bdf0deb
+size 17933

--- a/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_largefont.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_largefont.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56f4dae2e0670bc2ecfea39d0ebc1f399601bb98b28e6a0ca76aff923edccd5c
+size 22500

--- a/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_night.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_night.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c193dd1468f6fb69aeb1505e61c377b3c51ee6134e79302549625c570e46a00
+size 16699

--- a/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_small.png
+++ b/app-screenshot-tests/src/test/snapshots/images/__AppSettingsDialogPreview_small.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19ee68d3029a0316bb7c2578de48aad05e0ddbb8ed0c5a2e1affaa8141b247a5
+size 21673

--- a/notification/ui/src/main/kotlin/com/matejdro/micropebble/notifications/ui/apps/NotificationAppListScreen.kt
+++ b/notification/ui/src/main/kotlin/com/matejdro/micropebble/notifications/ui/apps/NotificationAppListScreen.kt
@@ -4,28 +4,34 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,6 +78,7 @@ class NotificationAppListScreen(
          NotificationAppListScreenContent(
             state = screenState,
             setAppEnabled = viewModel::setAppEnabled,
+            setAppAllowDuplicates = viewModel::setAppAllowDuplicates,
             setNotificationsPhoneMute = viewModel::setNotificationsPhoneMute,
             setCallsPhoneMute = viewModel::setCallsPhoneMute,
             setRespectDoNotDisturb = viewModel::setRespectDoNotDisturb,
@@ -87,6 +94,7 @@ class NotificationAppListScreen(
 private fun NotificationAppListScreenContent(
    state: NotificationAppListState,
    setAppEnabled: (String, Boolean) -> Unit,
+   setAppAllowDuplicates: (String, Boolean) -> Unit,
    setNotificationsPhoneMute: (Boolean) -> Unit,
    setCallsPhoneMute: (Boolean) -> Unit,
    setRespectDoNotDisturb: (Boolean) -> Unit,
@@ -94,6 +102,18 @@ private fun NotificationAppListScreenContent(
    setUseAndroidVibrationPatterns: (Boolean) -> Unit,
    setSendCalendarReminders: (Boolean) -> Unit,
 ) {
+   var selectedPackageName by rememberSaveable { mutableStateOf<String?>(null) }
+   val selectedApp = selectedPackageName?.let { pkg -> state.apps.find { it.app.packageName == pkg } }
+
+   if (selectedApp != null) {
+      AppSettingsDialog(
+         app = selectedApp,
+         setAppEnabled = { enabled -> setAppEnabled(selectedApp.app.packageName, enabled) },
+         setAllowDuplicates = { allow -> setAppAllowDuplicates(selectedApp.app.packageName, allow) },
+         onDismiss = { selectedPackageName = null },
+      )
+   }
+
    LazyColumn(
       Modifier.fillMaxSize(),
       contentPadding = WindowInsets.safeDrawing.asPaddingValues()
@@ -193,27 +213,77 @@ private fun NotificationAppListScreenContent(
       item { HorizontalDivider(Modifier.padding(vertical = 8.dp), color = MaterialTheme.colorScheme.onSurface) }
 
       itemsWithDivider(state.apps) { app ->
-         App(app, setAppEnabled = { setAppEnabled(app.app.packageName, it) })
+         App(
+            app = app,
+            setAppEnabled = { enabled -> setAppEnabled(app.app.packageName, enabled) },
+            onClick = { selectedPackageName = app.app.packageName },
+         )
       }
    }
 }
 
 @Composable
-private fun App(app: AppWithCount, setAppEnabled: (Boolean) -> Unit) {
+private fun App(app: AppWithCount, setAppEnabled: (Boolean) -> Unit, onClick: () -> Unit) {
    Row(
       Modifier
          .fillMaxSize()
+         .clickable(onClick = onClick)
          .padding(16.dp),
       horizontalArrangement = Arrangement.spacedBy(16.dp),
       verticalAlignment = Alignment.CenterVertically
    ) {
       AppIcon(app.app.packageName)
 
-      Text(app.app.name)
+      Text(text = app.app.name)
 
       Spacer(Modifier.weight(1f))
-      Switch(app.app.muteState == MuteState.Never, onCheckedChange = setAppEnabled)
+      Switch(checked = app.app.muteState == MuteState.Never, onCheckedChange = setAppEnabled)
    }
+}
+
+@Composable
+private fun AppSettingsDialog(
+   app: AppWithCount,
+   setAppEnabled: (Boolean) -> Unit,
+   setAllowDuplicates: (Boolean) -> Unit,
+   onDismiss: () -> Unit,
+) {
+   AlertDialog(
+      onDismissRequest = onDismiss,
+      title = { Text(text = app.app.name) },
+      text = {
+         Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+               Text(
+                  text = stringResource(R.string.notification_app_send_to_watch),
+                  modifier = Modifier.weight(1f),
+               )
+               Switch(
+                  checked = app.app.muteState == MuteState.Never,
+                  onCheckedChange = setAppEnabled,
+               )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+               Text(
+                  text = stringResource(R.string.notification_app_allow_duplicates),
+                  modifier = Modifier.weight(1f),
+               )
+               Switch(
+                  checked = app.app.allowDuplicates,
+                  onCheckedChange = setAllowDuplicates,
+               )
+            }
+         }
+      },
+      confirmButton = {
+         TextButton(onClick = onDismiss) {
+            Text(text = stringResource(R.string.done))
+         }
+      },
+   )
 }
 
 @Composable
@@ -245,6 +315,34 @@ private fun AppIcon(packageName: String) {
             }
          }
       }
+   }
+}
+
+@FullScreenPreviews
+@Composable
+@ShowkaseComposable(group = "Test")
+internal fun AppSettingsDialogPreview() {
+   PreviewTheme {
+      AppSettingsDialog(
+         app = AppWithCount(
+            NotificationAppItem(
+               packageName = "pkg.0",
+               name = "App 0",
+               muteState = MuteState.Never,
+               channelGroups = emptyList(),
+               stateUpdated = MillisecondInstant(Instant.DISTANT_PAST),
+               lastNotified = MillisecondInstant(Instant.DISTANT_PAST),
+               vibePatternName = null,
+               colorName = null,
+               iconCode = null,
+               allowDuplicates = true,
+            ),
+            count = 0,
+         ),
+         setAppEnabled = {},
+         setAllowDuplicates = {},
+         onDismiss = {},
+      )
    }
 }
 
@@ -283,6 +381,7 @@ internal fun NotificationAppListScreenContentPreview() {
 
       NotificationAppListScreenContent(
          state,
+         { _, _ -> },
          { _, _ -> },
          {},
          {},

--- a/notification/ui/src/main/kotlin/com/matejdro/micropebble/notifications/ui/apps/NotificationAppListViewModel.kt
+++ b/notification/ui/src/main/kotlin/com/matejdro/micropebble/notifications/ui/apps/NotificationAppListViewModel.kt
@@ -61,6 +61,14 @@ class NotificationAppListViewModel(
       notificationApps.updateNotificationAppMuteState(packageName, if (enabled) MuteState.Never else MuteState.Always)
    }
 
+   fun setAppAllowDuplicates(packageName: String, allowDuplicates: Boolean) {
+      actionLogger.logAction {
+         "NotificationAppListViewModel.setAppAllowDuplicates(packageName = $packageName, allowDuplicates = $allowDuplicates)"
+      }
+
+      notificationApps.updateNotificationAppAllowDuplicates(packageName, allowDuplicates)
+   }
+
    fun setNotificationsPhoneMute(mute: Boolean) {
       actionLogger.logAction { "NotificationAppListViewModel.toggleNotificationsPhoneMute()" }
 

--- a/notification/ui/src/main/res/values/strings.xml
+++ b/notification/ui/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="send_notifications_to_the_watch">Send notifications to the watch</string>
     <string name="show_calendar_reminders">Show calendar reminders\n(only affects future calendar events)</string>
     <string name="phone_notification_vibration">Respect phone\'s notification vibration patterns</string>
+    <string name="notification_app_send_to_watch">Send to watch</string>
+    <string name="notification_app_allow_duplicates">Allow duplicate notifications</string>
+    <string name="done">Done</string>
 </resources>


### PR DESCRIPTION
  Adds a per-app "Allow duplicate notifications" toggle. Tapping any app in the
  notification settings list now opens a small dialog with the existing "Send to
  watch" toggle plus the new one. When enabled, identical notifications from
  that app (e.g. recurring task reminders) are no longer suppressed by
  libpebble3's deduplication check and all reach the watch.

  Bumps the libpebble3 submodule to pick up the new
  `NotificationApps.updateNotificationAppAllowDuplicates` API.

  Depends on matejdro/libpebble3#3.

Addresses https://github.com/matejdro/microPebble/issues/73.

  ## Test plan

  - [x] Detekt + lint clean
  - [x] Paparazzi snapshots recorded for the new AppSettingsDialog (default,
        `_night`, `_small`, `_largefont`); existing list-screen snapshot unchanged
  - [x] Manual: open notification app list → tap an app → toggle "Allow duplicate
        notifications" on → trigger the app to send identical notifications →
        verify all reach the watch (instead of just the first)

