### PR TITLE
feat(KMP-1): add Compose Multiplatform and library-kmp-module convention plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
    implementation(libs.kotlin.plugin)
    implementation(libs.kotlin.plugin.compose)
    implementation(libs.kotlin.plugin.serialization)
+   implementation(libs.compose.gradlePlugin)
    implementation(libs.kotlinova.gradle)
    implementation(libs.metro.plugin)
    implementation(libs.moduleGraphAssert)

--- a/buildSrc/src/main/kotlin/library-kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/library-kmp-module.gradle.kts
@@ -1,0 +1,51 @@
+import dev.detekt.gradle.Detekt
+import tasks.setupTooManyKotlinFilesTaskForCommon
+
+plugins {
+   id("org.jetbrains.kotlin.multiplatform")
+   id("com.android.kotlin.multiplatform.library")
+   id("org.jetbrains.kotlin.plugin.compose")
+   id("org.jetbrains.compose")
+
+   id("checks")
+}
+
+val isMac = System.getProperty("os.name").contains("mac", ignoreCase = true)
+
+kotlin {
+   jvmToolchain(21)
+
+   androidLibrary {
+      // Modules with resources must override this.
+      namespace = "com.matejdro.micropebble.noresources"
+      compileSdk = 36
+      minSdk = 30
+   }
+
+   if (isMac) {
+      iosX64()
+      iosArm64()
+      iosSimulatorArm64()
+   }
+
+   compilerOptions {
+      optIn.add("kotlin.time.ExperimentalTime")
+      optIn.add("kotlin.uuid.ExperimentalUuidApi")
+      optIn.add("kotlin.ExperimentalUnsignedTypes")
+      freeCompilerArgs.add("-Xannotation-default-target=param-property")
+   }
+
+   sourceSets {
+      commonMain.dependencies {
+         implementation(compose.runtime)
+      }
+   }
+}
+
+if (name.startsWith("common-")) {
+   setupTooManyKotlinFilesTaskForCommon()
+}
+
+tasks.register("runDebugDetekt") {
+   dependsOn(tasks.withType<Detekt>())
+}

--- a/buildSrc/src/main/kotlin/util/PluginAccessors.kt
+++ b/buildSrc/src/main/kotlin/util/PluginAccessors.kt
@@ -16,6 +16,9 @@ inline val PluginDependenciesSpec.androidAppModule: PluginDependencySpec
 inline val PluginDependenciesSpec.androidLibraryModule: PluginDependencySpec
    get() = id("library-android-module")
 
+inline val PluginDependenciesSpec.kmpLibraryModule: PluginDependencySpec
+   get() = id("library-kmp-module")
+
 inline val PluginDependenciesSpec.pureKotlinModule: PluginDependencySpec
    get() = id("pure-kotlin-module")
 

--- a/config/libs.toml
+++ b/config/libs.toml
@@ -21,6 +21,8 @@ androidx-test-runner = "1.7.0"
 androidx-work = "2.11.2"
 coil = "3.4.0"
 composeDnd = "0.4.0"
+# @pin needs to match libpebble3's Compose Multiplatform version
+composeMultiplatform = "1.10.1"
 composePreference = "2.2.0"
 composeWebview = "0.33.6"
 dependencyAnalysis = "3.15.0"
@@ -102,6 +104,8 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 coil = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 composeDnd = { module = "com.mohamedrejeb.dnd:compose-dnd", version.ref = "composeDnd" }
+# Compose Multiplatform Gradle plugin, used by the library-kmp-module convention plugin in buildSrc
+compose-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "composeMultiplatform" }
 composePreference = { module = "me.zhanghai.compose.preference:preference", version.ref = "composePreference" }
 composeWebview = { module = "io.github.kevinnzou:compose-webview", version.ref = "composeWebview" }
 dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysis" }


### PR DESCRIPTION
Introduces a library-kmp-module convention plugin in buildSrc so modules can target Android and iOS with Compose Multiplatform. Uses the AGP com.android.kotlin.multiplatform.library plugin (avoids the kotlin.android <-> kotlin.multiplatform conflict) and gates iOS targets to macOS.